### PR TITLE
Fix link to exiv2 sources

### DIFF
--- a/net.sourceforge.Hugin.json
+++ b/net.sourceforge.Hugin.json
@@ -204,7 +204,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://www.exiv2.org/builds/exiv2-0.27.5-Source.tar.gz",
+                    "url": "https://github.com/Exiv2/exiv2/releases/download/v0.27.5/exiv2-0.27.5-Source.tar.gz",
                     "sha256": "35a58618ab236a901ca4928b0ad8b31007ebdc0386d904409d825024e45ea6e2"
                 }
             ]


### PR DESCRIPTION
The link to exiv2.org does not work anymore.