### PR TITLE
Build enfuse/enblend with multi-core support

### DIFF
--- a/net.sourceforge.Hugin.json
+++ b/net.sourceforge.Hugin.json
@@ -216,6 +216,9 @@
             "cleanup": [
                 "/share/man"
             ],
+            "config-opts": [
+                "-DENABLE_OPENMP=on"
+            ],
             "modules": [
                 {
                     "name": "gsl",


### PR DESCRIPTION
Building enblend with openmp allows multi-core usage and thus much faster blending.